### PR TITLE
combine tls cert files in changes.ldif

### DIFF
--- a/ellis.sh
+++ b/ellis.sh
@@ -848,13 +848,11 @@ olcRootPW: $(cat /etc/openldap/passwd)
 
 dn: cn=config
 changetype: modify
-replace: olcTLSCertificateFile
-olcTLSCertificateFile: /etc/openldap/certs/cert.pem
-
-dn: cn=config
-changetype: modify
 replace: olcTLSCertificateKeyFile
 olcTLSCertificateKeyFile: /etc/openldap/certs/priv.pem
+-
+replace: olcTLSCertificateFile
+olcTLSCertificateFile: /etc/openldap/certs/cert.pem
 
 dn: cn=config
 changetype: modify


### PR DESCRIPTION
Changed changes.ldif to include olcTLSCertificateKeyFile and olcTLSCertificateFile to be modified at the same time. This was causing an error 80 in RH7.5.
ref: https://github.com/ansible/ansible/issues/25665